### PR TITLE
refactor(user): 서포터서비스계층 리팩토링(아래상세)

### DIFF
--- a/src/main/java/com/moa/backend/domain/user/service/SupporterProfileService.java
+++ b/src/main/java/com/moa/backend/domain/user/service/SupporterProfileService.java
@@ -1,26 +1,25 @@
 package com.moa.backend.domain.user.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moa.backend.domain.follow.dto.SimpleMakerSummary;
+import com.moa.backend.domain.follow.dto.SimpleSupporterSummary;
 import com.moa.backend.domain.follow.entity.SupporterFollowMaker;
 import com.moa.backend.domain.follow.entity.SupporterFollowSupporter;
 import com.moa.backend.domain.follow.repository.SupporterFollowMakerRepository;
 import com.moa.backend.domain.follow.repository.SupporterFollowSupporterRepository;
 import com.moa.backend.domain.maker.entity.Maker;
-import com.moa.backend.domain.follow.dto.SimpleMakerSummary;
-import com.moa.backend.domain.follow.dto.SimpleSupporterSummary;
 import com.moa.backend.domain.user.dto.SupporterProfileResponse;
 import com.moa.backend.domain.user.dto.SupporterProfileUpdateRequest;
 import com.moa.backend.domain.user.entity.SupporterProfile;
 import com.moa.backend.domain.user.repository.SupporterProfileRepository;
+import com.moa.backend.global.error.AppException;
+import com.moa.backend.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 @Service
@@ -30,29 +29,50 @@ public class SupporterProfileService {
     private final SupporterProfileRepository supporterProfileRepository;
     private final ObjectMapper objectMapper;
 
-    // 팔로우 정보 조회용
     private final SupporterFollowSupporterRepository supporterFollowSupporterRepository;
     private final SupporterFollowMakerRepository supporterFollowMakerRepository;
 
     /**
-     * 내 서포터 프로필 조회 (+ 내가 팔로우한 서포터/메이커 정보까지 포함)
+     * 내 서포터 프로필 조회
+     * - 기본 프로필 정보
+     * - 내가 팔로우한 서포터/메이커 카운트 + 리스트까지 함께 포함
      */
     @Transactional(readOnly = true)
     public SupporterProfileResponse getProfile(Long userId) {
-        SupporterProfile profile = supporterProfileRepository.findByUserId(userId)
-                .orElseThrow(() -> new IllegalArgumentException("서포터 프로필을 찾을 수 없습니다."));
-
+        SupporterProfile profile = getProfileOrThrow(userId);
         return toResponseWithFollows(profile);
     }
 
     /**
-     * 내 서포터 프로필 수정 (+ 수정 후 최신 팔로우 정보까지 포함해서 반환)
+     * 내 서포터 프로필 수정
+     * - 수정 후 최신 팔로우 정보까지 포함해서 응답
      */
     @Transactional
     public SupporterProfileResponse updateProfile(Long userId, SupporterProfileUpdateRequest request) {
-        SupporterProfile profile = supporterProfileRepository.findByUserId(userId)
-                .orElseThrow(() -> new IllegalArgumentException("서포터 프로필을 찾을 수 없습니다."));
+        SupporterProfile profile = getProfileOrThrow(userId);
 
+        applyUpdates(profile, request);
+
+        return toResponseWithFollows(profile);
+    }
+
+    // ================== 내부 헬퍼 메서드 ==================
+
+    /**
+     * userId 기준으로 서포터 프로필 조회
+     * 없으면 AppException(NOT_FOUND) 발생
+     */
+    private SupporterProfile getProfileOrThrow(Long userId) {
+        return supporterProfileRepository.findByUserId(userId)
+                .orElseThrow(() ->
+                        new AppException(ErrorCode.NOT_FOUND, "서포터 프로필을 찾을 수 없습니다."));
+    }
+
+    /**
+     * 요청값 기반으로 SupporterProfile 필드 업데이트
+     * (null이 아닌 값만 반영)
+     */
+    private void applyUpdates(SupporterProfile profile, SupporterProfileUpdateRequest request) {
         if (request.displayName() != null) {
             profile.updateDisplayName(request.displayName());
         }
@@ -75,18 +95,35 @@ public class SupporterProfileService {
             profile.updatePostalCode(request.postalCode());
         }
         if (request.interests() != null) {
-            profile.updateInterests(toJson(request.interests())); // List<String> → JSON 문자열
+            // List<String> → JSON 문자열로 저장
+            profile.updateInterests(toJson(request.interests()));
         }
-
-        return toResponseWithFollows(profile);
     }
 
     /**
-     * 서포터 프로필 + 팔로우 카운트/리스트까지 포함한 DTO로 변환
+     * 서포터 프로필 + 팔로우 정보까지 포함한 응답 DTO 생성
+     *
+     * 1. SupporterProfileResponse.of(...) 로 기본 프로필/관심사 매핑
+     * 2. 팔로우 쿼리로 카운트/리스트 가져와서 다시 record 생성
      */
     private SupporterProfileResponse toResponseWithFollows(SupporterProfile profile) {
 
-        // 1) 내가 팔로우한 서포터/메이커 관계 조회
+        // 1) 기본 프로필 부분은 기존 팩토리 메서드 재사용
+        SupporterProfileResponse base = SupporterProfileResponse.of(
+                profile.getUserId(),
+                profile.getDisplayName(),
+                profile.getBio(),
+                profile.getImageUrl(),
+                profile.getPhone(),
+                profile.getAddress1(),
+                profile.getAddress2(),
+                profile.getPostalCode(),
+                profile.getInterests(),      // JSON 문자열
+                profile.getCreatedAt(),
+                profile.getUpdatedAt()
+        );
+
+        // 2) 팔로우 관계 조회
         List<SupporterFollowSupporter> supporterRelations =
                 supporterFollowSupporterRepository.findByFollower(profile);
 
@@ -96,19 +133,19 @@ public class SupporterProfileService {
         long followingSupporterCount = supporterRelations.size();
         long followingMakerCount = makerRelations.size();
 
-        // 2) 서포터 요약 DTO 리스트
+        // 3) 서포터 요약 DTO 리스트 매핑
         List<SimpleSupporterSummary> followingSupporters = supporterRelations.stream()
                 .map(rel -> {
                     SupporterProfile target = rel.getFollowing();
                     return new SimpleSupporterSummary(
-                            target.getUserId(),          // PK = user_id
+                            target.getUserId(),          // supporter_profiles.user_id
                             target.getDisplayName(),
                             target.getImageUrl()
                     );
                 })
                 .collect(Collectors.toList());
 
-        // 3) 메이커 요약 DTO 리스트
+        // 4) 메이커 요약 DTO 리스트 매핑
         List<SimpleMakerSummary> followingMakers = makerRelations.stream()
                 .map(rel -> {
                     Maker maker = rel.getMaker();
@@ -120,41 +157,24 @@ public class SupporterProfileService {
                 })
                 .collect(Collectors.toList());
 
-        // 4) interests(JSON 문자열 → List<String>) 파싱
-        List<String> interests = parseInterests(profile.getInterests());
-
-        // 5) 최종 응답 DTO 생성
+        // 5) 기본 프로필 + 팔로우 정보까지 합쳐서 최종 DTO 생성
         return new SupporterProfileResponse(
-                profile.getUserId(),
-                profile.getDisplayName(),
-                profile.getBio(),
-                profile.getImageUrl(),
-                profile.getPhone(),
-                profile.getAddress1(),
-                profile.getAddress2(),
-                profile.getPostalCode(),
-                interests,
-                profile.getCreatedAt(),
-                profile.getUpdatedAt(),
+                base.userId(),
+                base.displayName(),
+                base.bio(),
+                base.imageUrl(),
+                base.phone(),
+                base.address1(),
+                base.address2(),
+                base.postalCode(),
+                base.interests(),
+                base.createdAt(),
+                base.updatedAt(),
                 followingSupporterCount,
                 followingMakerCount,
                 followingSupporters,
                 followingMakers
         );
-    }
-
-    /**
-     * "['React','Spring']" 이런 JSON 문자열 → List<String>
-     */
-    private List<String> parseInterests(String raw) {
-        if (raw == null || raw.isBlank()) {
-            return Collections.emptyList();
-        }
-        try {
-            return objectMapper.readValue(raw, new TypeReference<List<String>>() {});
-        } catch (Exception e) {
-            return Collections.emptyList();
-        }
     }
 
     /**


### PR DESCRIPTION
- SupporterProfileResponse에 팔로우 정보 필드 추가
  - followingSupporterCount: 내가 팔로우한 서포터 수
  - followingMakerCount: 내가 팔로우한 메이커 수
  - followingSupporters: SimpleSupporterSummary 리스트
  - followingMakers: SimpleMakerSummary 리스트

- SupporterProfileResponse.of(...) 유지
  - 기존처럼 "프로필만" 필요할 때도 사용 가능
  - 팔로우 필드는 기본값(0, empty list)으로 초기화되도록 처리

- 팔로우 요약 DTO 추가
  - SimpleSupporterSummary (supporterUserId, displayName, imageUrl)
  - SimpleMakerSummary (makerId, name, imageUrl)
  - 패키지: com.moa.backend.domain.follow.dto

- SupporterProfileService 리팩토링
  - getProfile(userId): 프로필 + 팔로우 정보까지 한 번에 조회
  - updateProfile(userId, request): 프로필 수정 후 동일한 응답 형태 유지
  - getProfileOrThrow(userId)로 프로필 조회 + 예외 처리 로직 분리
  - applyUpdates(profile, request)로 수정 로직 분리
  - toResponseWithFollows(profile)에서
    - SupporterProfileResponse.of(...)로 기본 프로필 매핑
    - supporter_follows_supporter / supporter_follows_maker 조회 후 팔로우 카운트 및 요약 DTO 리스트 조립

- 예외 처리 통일
  - 서포터 프로필 미존재 시 AppException(ErrorCode.NOT_FOUND) 사용
  - 서비스 레이어에서 IllegalArgumentException 대신 도메인 공통 에러 코드 사용